### PR TITLE
Allow unmatched step on step containing non ascii characters.

### DIFF
--- a/planterbox_webdriver/css_selector_steps.py
+++ b/planterbox_webdriver/css_selector_steps.py
@@ -52,7 +52,7 @@ def find_element_by_jquery(test, browser, selector):
     """Find a single HTML element using jQuery-style selectors."""
     elements = find_elements_by_jquery(browser, selector)
     test.assertGreater(len(elements), 0,
-                       'No elements matched: {}'.format(selector))
+                       u'No elements matched: {}'.format(selector))
     return elements[0]
 
 


### PR DESCRIPTION
Test with an unmatched step, that also contained unicode was throwing following exception;

```
======================================================================
ERROR: Unicode (winslow.tests.features:unicode.feature:3)
While logged in
----------------------------------------------------------------------
Scenario: A Favorited search including unicode should return results
    Given I point browser to "favorites"
    Then there should be an element matching $("a:contains('35 U.S.C. §285')") within 10 seconds
    When I click $("a:contains('35 U.S.C. §285')")
Traceback (most recent call last):
  File "/home/shawn/.virtualenvs/deus_lex/local/lib/python2.7/site-packages/planterbox/__init__.py", line 202, in run_scenario
    step_fn(self, *step_arguments)
  File "/home/shawn/.virtualenvs/deus_lex/local/lib/python2.7/site-packages/planterbox_webdriver/css_selector_steps.py", line 121, in click_by_selector
    elem = find_element_by_jquery(test, test.browser, selector)
  File "/home/shawn/.virtualenvs/deus_lex/local/lib/python2.7/site-packages/planterbox_webdriver/css_selector_steps.py", line 55, in find_element_by_jquery
    'No elements matched: {}'.format(selector))
UnicodeEncodeError: 'ascii' codec can't encode character u'\xa7' in position 22: ordinal not in range(128)
```
